### PR TITLE
meanImage has the wrong tensor size

### DIFF
--- a/util/DataLoader.lua
+++ b/util/DataLoader.lua
@@ -326,7 +326,7 @@ function getMeanTrainingImage(videoPaths, fullDumpPath, opt)
     end
   end
 
-  local meanImage = torch.Tensor(opt.numChannels, opt.scaledHeight, opt.scaledHeight)
+  local meanImage = torch.Tensor(opt.numChannels, opt.scaledWidth, opt.scaledHeight)
   for i = 1, opt.numChannels do
     meanImage[i]:fill(means[i] / numFrames)
   end

--- a/util/DataLoader.lua
+++ b/util/DataLoader.lua
@@ -326,7 +326,7 @@ function getMeanTrainingImage(videoPaths, fullDumpPath, opt)
     end
   end
 
-  local meanImage = torch.Tensor(opt.numChannels, opt.scaledWidth, opt.scaledHeight)
+  local meanImage = torch.Tensor(opt.numChannels, opt.scaledHeight, opt.scaledWidth)
   for i = 1, opt.numChannels do
     meanImage[i]:fill(means[i] / numFrames)
   end


### PR DESCRIPTION
Hi Gary - I took the liberty of fixing this as the code wouldn't compile and spit out the invalid Tensor size error at line 93 in DataLoader

videoTensor[i] = videoTensor[i] - self.splits.train.mean

If this isn't the correct fix or please reject the pull request

